### PR TITLE
Website layout quarter icon out of order

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,11 +535,10 @@
             <div class="ui-showcase-blocks ui-steps">
                 <!-- Step 1 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q1</span>
                     <div class="row">
                         <div class="col-md-6 text-md-right" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
-                                2020
+                                2021
                             </h4>
                             <p class="paragraph" data-content="section_Roadmap_Title_1">Create a Beta consumer version
                                 for Android, Mac, Windows and Linux.</p>
@@ -548,11 +547,10 @@
                 </div>
                 <!-- Step 2 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q2</span>
                     <div class="row">
                         <div class="col-md-6" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
-                                2021
+                                2022
                             </h4>
                             <p class="paragraph" data-content="section_Roadmap_Title_2">Implement internal Python
                                 Blockchain based on Bismuth.</p>
@@ -561,11 +559,10 @@
                 </div>
                 <!-- Step 3 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q3</span>
                     <div class="row">
                         <div class="col-md-6 text-md-right" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
-                                2022
+                                2023
                             </h4>
                             <p class="paragraph" data-content="section_Roadmap_Title_3">Implement Automatic Data
                                 Rebuilding for the ReBuilders.</p>
@@ -574,11 +571,10 @@
                 </div>
                 <!-- Step 4 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q4</span>
                     <div class="row">
                         <div class="col-md-6" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
-                                2022
+                                2023
                             </h4>
                             <p class="paragraph" data-content="section_Roadmap_Title_4">Launch native BitDust token</p>
                         </div>

--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
             <div class="ui-showcase-blocks ui-steps">
                 <!-- Step 1 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q3</span>
+                    <span class="step-number ui-gradient-peach">Q1</span>
                     <div class="row">
                         <div class="col-md-6 text-md-right" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
@@ -548,7 +548,7 @@
                 </div>
                 <!-- Step 2 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q1</span>
+                    <span class="step-number ui-gradient-peach">Q2</span>
                     <div class="row">
                         <div class="col-md-6" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
@@ -561,7 +561,7 @@
                 </div>
                 <!-- Step 3 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q1</span>
+                    <span class="step-number ui-gradient-peach">Q3</span>
                     <div class="row">
                         <div class="col-md-6 text-md-right" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">
@@ -574,7 +574,7 @@
                 </div>
                 <!-- Step 4 -->
                 <div class="step-wrapper">
-                    <span class="step-number ui-gradient-peach">Q3</span>
+                    <span class="step-number ui-gradient-peach">Q4</span>
                     <div class="row">
                         <div class="col-md-6" data-vertical_center="true">
                             <h4 class="heading text-dark-gray">


### PR DESCRIPTION
Removed Q labels and shifted #roadmap year +1.